### PR TITLE
Add initial smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ a11y: demo-build
 	@PA11Y=true DEMO_MODE=true node demos/app
 	@$(DONE)
 
-# test: verify
-# 	make smoke unit-test
+test: verify
+	make a11y-demo
 
-# unit-test:
-# 	mocha --recursive
+a11y-demo:
+	export TEST_URL=http://localhost:5005; \
+	make a11y
 
-# smoke:
-# 	export TEST_URL=http://localhost:5005; \
-# 	make a11y
+smoke:
+	n-test smoke --host http://localhost:5005

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.0",
     "@financial-times/n-internal-tool": "^2.2.2",
+    "@financial-times/n-test": "^1.0.1",
     "@financial-times/n-webpack": "^3.1.0",
     "bower": "^1.8.2",
     "chai": "^4.1.2",

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,14 @@
+module.exports = [
+	{
+		name: 'button',
+		urls: {
+			'/': {
+				status: 200,
+				pageErrors: 0,
+				content: (content) => {
+					return content.includes('swg.js');
+				}
+			}
+		}
+	}
+];


### PR DESCRIPTION
There are no unit tests because I think smoke/integration style tests will work better since there's so much DOM work involved.

There's currently work going on for GDPR around using [cypress](https://www.cypress.io/) so for the moment, these basic smoke tests will have to do until we have some consensus around the way forward in this regard.

 🐿 v2.7.0