### PR TITLE
At/tracking

### DIFF
--- a/src/client/subscribe-button/index.js
+++ b/src/client/subscribe-button/index.js
@@ -6,9 +6,10 @@ class SubscribeButtons {
 		this.buttons = Array.from(document.querySelectorAll(selector));
 		this.swgClient = swgClient;
 		this.overlay = overlay || new Overlay();
-		this.trackEvent = SwgController.trackEvent;
-		this.onSwgReturn = SwgController.onReturn;
-		this.onSwgError = SwgController.onError;
+		this.signal = SwgController.signal;
+		this.listen = SwgController.listen;
+		// this.onSwgReturn = SwgController.onReturn;
+		// this.onSwgError = SwgController.onError;
 		this.disableButtons();
 	}
 
@@ -16,8 +17,8 @@ class SubscribeButtons {
 		this.buttons.forEach((btn) => {
 			btn.addEventListener('click', this.handleClick.bind(this));
 		});
-		if (this.onSwgReturn) this.onSwgReturn(this.onReturn.bind(this));
-		if (this.onSwgError) this.onSwgError(this.onReturn.bind(this));
+		this.listen('onReturn', this.onReturn.bind(this));
+		this.listen('onError', this.onReturn.bind(this));
 
 		this.enableButtons();
 	}
@@ -25,12 +26,13 @@ class SubscribeButtons {
 	handleClick (event) {
 		event.preventDefault();
 
-		this.overlay.show();
+		// this.overlay.show();
 
 		try {
 			const skus = event.target.getAttribute('data-n-swg-button-skus').split(',');
 
-			this.trackEvent('landing', {});
+			this.signal('track', { action: 'landing', context: { skus }, journeyStart: true });
+			// this.trackEvent('landing', {});
 
 			if (skus.length > 1) {
 				this.swgClient.showOffers({ skus });

--- a/src/client/subscribe-button/index.js
+++ b/src/client/subscribe-button/index.js
@@ -8,8 +8,6 @@ class SubscribeButtons {
 		this.overlay = overlay || new Overlay();
 		this.signal = SwgController.signal;
 		this.listen = SwgController.listen;
-		// this.onSwgReturn = SwgController.onReturn;
-		// this.onSwgError = SwgController.onError;
 		this.disableButtons();
 	}
 
@@ -18,7 +16,7 @@ class SubscribeButtons {
 			btn.addEventListener('click', this.handleClick.bind(this));
 		});
 		this.listen('onReturn', this.onReturn.bind(this));
-		this.listen('onError', this.onReturn.bind(this));
+		this.listen('onError', this.onError.bind(this));
 
 		this.enableButtons();
 	}
@@ -26,13 +24,12 @@ class SubscribeButtons {
 	handleClick (event) {
 		event.preventDefault();
 
-		// this.overlay.show();
+		this.overlay.show();
 
 		try {
 			const skus = event.target.getAttribute('data-n-swg-button-skus').split(',');
 
 			this.signal('track', { action: 'landing', context: { skus }, journeyStart: true });
-			// this.trackEvent('landing', {});
 
 			if (skus.length > 1) {
 				this.swgClient.showOffers({ skus });

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -9,7 +9,7 @@ class SwgController {
 	constructor (swgClient, options={}, subscribeButtonConstructor=SubscribeButtons, overlay) {
 		/* options */
 		this.manualInitDomain = options.manualInitDomain;
-		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || 'https://swg-fulfilment-svc-eu-test.memb.ft.com/subscriptions';
+		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || (options.sandbox ? 'https://swg-fulfilment-svc-eu-test.memb.ft.com/subscriptions' : 'https://swg-fulfilment-svc-eu-prod.memb.ft.com/subscriptions');
 
 		this.alreadyInitialised = false;
 		this.swgClient = swgClient;

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -18,6 +18,9 @@ class SwgController {
 		if (options.subscribeFromButton) {
 			this.subscribeButtons = new subscribeButtonConstructor(swgClient, { SwgController });
 		};
+
+		this.baseTrackingData = SwgController.generateTrackingData(options);
+		this.activeTrackingData;
 	}
 
 	static load ({ manual=false, swgPromise=swgReady(), loadClient=importClient, sandbox=false }={}) {
@@ -37,8 +40,11 @@ class SwgController {
 			if (this.manualInitDomain) {
 				this.swgClient.init(this.manualInitDomain);
 			}
-			// bind handlers
+			// bind swg handlers
 			this.swgClient.setOnSubscribeResponse(this.handlers.onSubscribeResponse.bind(this));
+
+			// bind own handlers
+			SwgController.listen('track', this.track.bind(this));
 
 			this.alreadyInitialised = true;
 		}
@@ -51,17 +57,19 @@ class SwgController {
 	onSubscribeResponse (subPromise) {
 		subPromise.then((response) => {
 			this.signalReturn(response);
-			SwgController.trackEvent('success', {});
+			this.track({ action: 'success', context: {} });
 			this.resolveUser(response).then(() => {
-				SwgController.trackEvent('confirmation', {});
+				this.track({ action: 'confirmation', context: {
+					// subscriptionId: response.subscriptionId
+				}});
 				// !TODO: redirect the now logged in user to relevant page
 			});
 		}).catch((err) => {
 			this.signalError(err);
-			SwgController.trackEvent('exit', {
+			this.track({ action: 'exit', context: {
 				errCode: _get(err, 'activityResult.code'),
 				errData: _get(err, 'activityResult.data'),
-			});
+			}});
 		});
 	}
 
@@ -118,12 +126,17 @@ class SwgController {
 		});
 	}
 
-	static trackEvent (action, context={}, eventConstructor=CustomEvent) {
-		const detail = Object.assign({}, context, {
-			category: 'SwG',
-			action,
-			system: { source: 'n-swg' }
-		});
+	track ({ action, context={}, journeyStart=false }={}) {
+		const offerData = SwgController.generateOfferDataFromSku(context.skus);
+		if (offerData && journeyStart) {
+			// update the activeTrackingData state to include active offer
+			this.activeTrackingData = offerData;
+		}
+		const decoratedEvent = Object.assign({}, this.baseTrackingData, this.activeTrackingData, context, { action });
+		SwgController.trackEvent(decoratedEvent);
+	}
+
+	static trackEvent (detail, eventConstructor=CustomEvent) {
 		document.body.dispatchEvent(new eventConstructor('oTracking.event', { detail, bubbles: true }));
 	}
 
@@ -137,13 +150,50 @@ class SwgController {
 		});
 	}
 
-	static onReturn (listener) {
-		SwgController.listen('onReturn', listener);
+	static generateTrackingData (options={}) {
+		return {
+			category: 'SwG',
+			formType: 'signup:swg',
+			production: !options.sandbox,
+			paymentMethod: 'SWG',
+			system: { source: 'n-swg' }
+		};
 	}
 
-	static onError (listener) {
-		SwgController.listen('onError', listener);
+	static generateOfferDataFromSku (skus=[]) {
+		if (skus.length !== 1) return {};
+		/**
+		 * skus SHOULD follow the format
+		 * ft.com_OFFER.ID_TERM_NAME.TRIAL_DATE
+		 * note: currently ft.com_OFFERID_TERM
+		 * ie:
+		 * ft.com_abcd38.efg89_p1m_premium.trial_31.05.18
+		 * ft.com_abcd38.efg89_p1y_standard_31.05.18
+		 */
+		const [ domain, offerId, term, name ] = skus[0].toLowerCase().split('_');
+		const strContainsVal = (s, v) => s && s.indexOf(v) !== -1;
+		if (strContainsVal(domain, 'ft.com')) {
+			return {
+				offerId: offerId && offerId.replace(/\./g, '-'),
+				skuId: skus[0],
+				productName: name && name.replace('.', ' '),
+				term,
+				productType: 'Digital',
+				isTrial: strContainsVal(name, 'trial'),
+				isPremium: strContainsVal(name, 'premium')
+			};
+		} else {
+			return {};
+		}
 	}
+
+	// static onReturn (listener) {
+	// 	SwgController.listen('onReturn', listener);
+	// }
+
+	// static onError (listener) {
+	// 	SwgController.listen('onError', listener);
+	// }
 
 }
 

--- a/test/client/mocks/swg-client.js
+++ b/test/client/mocks/swg-client.js
@@ -22,6 +22,10 @@ class SwgClient {
 		return true;
 	}
 
+	showOffers () {
+		return true;
+	}
+
 	subscribe () {
 		return true;
 	}

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -39,7 +39,7 @@ describe('Swg Controller: class', function () {
 			expect(subject.handlers.onEntitlementsResponse).to.be.a('Function');
 			expect(subject.swgClient).to.deep.equal(swgClient);
 			expect(subject.overlay).to.be.an.instanceOf(Overlay);
-			expect(subject.M_SWG_SUB_SUCCESS_ENDPOINT).to.equal('https://swg-fulfilment-svc-eu-test.memb.ft.com/subscriptions');
+			expect(subject.M_SWG_SUB_SUCCESS_ENDPOINT).to.equal('https://swg-fulfilment-svc-eu-prod.memb.ft.com/subscriptions');
 		});
 
 		it('accepts custom options', function () {


### PR DESCRIPTION
- tracking the flow like we do signup
- maintains a state of the "active" offer/sku for the various events
- simplify the event/listener pattern
- update membership endpoints
- update subscription success onward journey