### PR TITLE
Fix issue with bower module

### DIFF
--- a/demos/controllers/mock-endpoints.js
+++ b/demos/controllers/mock-endpoints.js
@@ -1,4 +1,3 @@
-const _get = require('lodash.get');
 const logger = require('@financial-times/n-logger').default;
 const SESSION_COOKIE_EXPIRY = 15552000000;
 
@@ -15,7 +14,7 @@ const generateMockCookie = (res, cookies=[]) => {
 };
 
 const generateCookieData = ({ body }={}) => {
-	const purchaseData = _get(body, 'purchaseData');
+	const purchaseData = body && body.purchaseData;
 	if (!purchaseData) {
 		// entitlements success
 		return [{

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-swg#readme",
   "dependencies": {
-    "@financial-times/n-gage": "^1.19.6",
-    "lodash.get": "^4.4.2"
+    "@financial-times/n-gage": "^1.19.6"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.0",
@@ -41,6 +40,7 @@
     "css-loader": "^0.28.7",
     "eslint": "^4.13.1",
     "jsdom": "^11.6.2",
+    "lodash.get": "^4.4.2",
     "mocha": "^5.0.1",
     "node-sass": "^4.7.2",
     "nodemon": "^1.14.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "css-loader": "^0.28.7",
     "eslint": "^4.13.1",
     "jsdom": "^11.6.2",
-    "lodash.get": "^4.4.2",
     "mocha": "^5.0.1",
     "node-sass": "^4.7.2",
     "nodemon": "^1.14.12",

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -1,6 +1,5 @@
-import { swgReady, importClient, Overlay } from './utils';
+import { swgReady, importClient, Overlay, _get } from './utils';
 import SubscribeButtons from './subscribe-button';
-import _get from 'lodash.get';
 
 class SwgController {
 	/**

--- a/src/client/utils/deep-get.js
+++ b/src/client/utils/deep-get.js
@@ -1,0 +1,13 @@
+module.exports = (obj={}, str='') => {
+	if (typeof obj !== 'object' || typeof str !== 'string') return undefined;
+	let paths = str.split('.');
+	let current = obj;
+	for (let i = 0; i < paths.length; ++i) {
+		if (current[paths[i]] === undefined) {
+			return undefined;
+		} else {
+			current = current[paths[i]];
+		}
+	}
+	return current;
+};

--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -1,9 +1,11 @@
 import importClient from './swg-client-loader';
 import Overlay from './overlay';
 import swgReady from './swg-ready';
+import _get from './deep-get';
 
 module.exports = {
 	importClient,
 	Overlay,
-	swgReady
+	swgReady,
+	_get
 };

--- a/test/client/utils/deep-get.spec.js
+++ b/test/client/utils/deep-get.spec.js
@@ -1,0 +1,21 @@
+const { expect } = require('chai');
+
+const _get = require('../../../src/client/utils/deep-get');
+
+describe('Util: deep-get.js', function () {
+
+	it('return deep value from an object', function () {
+		const MOCK = { foo: { bar: { baz: 'bang' } } };
+		expect(_get(MOCK, 'foo.bar.baz')).to.equal('bang');
+	});
+
+	it('return undefined if not found', function () {
+		const MOCK = { foo: { bar: { wiz: 'bang' } } };
+		expect(_get(MOCK, 'foo.bar.baz')).to.equal(undefined);
+	});
+
+	it('return undefined if invalid parameters', function () {
+		expect(_get('string', 'foo.bar.baz')).to.equal(undefined);
+	});
+
+});


### PR DESCRIPTION
Lodash.get is not available in client side bundle so caused an
error in bower module export.
```
Cannot complete build due to compilation error from build tools:
./bower_components/n-swg/src/client/swg-controller.js Module not
found: Error: Can't resolve 'lodash.get' in
'./bower_components/n-swg/src/client'
```

Rather than depend on lodash I have added a simple util to
replace its limited usage.

---

Example error: https://www.ft.com/__origami/service/build/v2/bundles/js?modules=n-swg@^0.3.0

 🐿 v2.7.0