### PR TITLE
Allow the consuming client to customise onward journeys

### DIFF
--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -143,21 +143,22 @@ describe('Swg Controller: class', function () {
 				.catch(done);
 			});
 
-			it('if granted access will showOverlay, resolve user and call onwardEntitledJourney(!promptLogin)', function (done) {
+			it('if granted access will showOverlay, resolve user and call handlers.onResolvedEntitlements(!promptLogin)', function (done) {
 				const subject = new SwgController(swgClient);
 				const checkEntitlementsPromise = Promise.resolve({ granted: true });
 				const resolveUserPromise = Promise.resolve();
 				sinon.stub(subject, 'checkEntitlements').returns(checkEntitlementsPromise);
 				sinon.stub(subject, 'resolveUser').returns(resolveUserPromise);
-				sinon.stub(subject, 'onwardEntitledJourney');
+				sinon.stub(subject.handlers, 'onResolvedEntitlements');
+
 
 				subject.init();
 				checkEntitlementsPromise.then(() => {
 					resolveUserPromise.then(() => {
-						expect(subject.onwardEntitledJourney.calledWith({ promptLogin: false })).to.be.true;
+						expect(subject.handlers.onResolvedEntitlements.calledWith(sinon.match({ promptLogin: false }))).to.be.true;
 						subject.resolveUser.restore();
 						subject.checkEntitlements.restore();
-						subject.onwardEntitledJourney.restore();
+						subject.handlers.onResolvedEntitlements.restore();
 						done();
 					})
 					.catch(done);
@@ -172,7 +173,7 @@ describe('Swg Controller: class', function () {
 				sinon.stub(subject, 'checkEntitlements').returns(checkEntitlementsPromise);
 				sinon.stub(subject, 'resolveUser').returns(resolveUserPromise);
 				sinon.stub(SwgController, 'signalError');
-				sinon.stub(subject, 'onwardEntitledJourney');
+				sinon.stub(subject.handlers, 'onResolvedEntitlements');
 
 				subject.init();
 				checkEntitlementsPromise.then(() => {
@@ -184,11 +185,11 @@ describe('Swg Controller: class', function () {
 					})
 					.then(() => {
 						expect(SwgController.signalError.calledOnce).to.be.true;
-						expect(subject.onwardEntitledJourney.calledWith({ promptLogin: true })).to.be.true;
+						expect(subject.handlers.onResolvedEntitlements.calledWith(sinon.match({ promptLogin: true }))).to.be.true;
 						subject.resolveUser.restore();
 						subject.checkEntitlements.restore();
 						SwgController.signalError.restore();
-						subject.onwardEntitledJourney.restore();
+						subject.handlers.onResolvedEntitlements.restore();
 						done();
 					})
 					.catch(done);
@@ -240,7 +241,7 @@ describe('Swg Controller: class', function () {
 			subject = null;
 		});
 
-		it('on subPromise success: disable buttons, signal return, track success, resolve user -> onwardSubscribedJourney()', function (done) {
+		it('on subPromise success: disable buttons, signal return, track success, resolve user -> handlers.onResolvedSubscribe()', function (done) {
 			const mockResponseComplete = Promise.resolve();
 			const MOCK_RESULT = { mock: 'swg-result', complete: () => mockResponseComplete };
 			const subPromise = Promise.resolve(MOCK_RESULT);
@@ -248,7 +249,7 @@ describe('Swg Controller: class', function () {
 
 			sinon.stub(subject, 'resolveUser').returns(resolveUserPromise);
 			sinon.stub(subject.subscribeButtons, 'disableButtons');
-			sinon.spy(subject, 'onwardSubscribedJourney');
+			sinon.spy(subject.handlers, 'onResolvedSubscribe');
 			subject.onSubscribeResponse(subPromise);
 
 			subPromise.then(() => {
@@ -260,11 +261,11 @@ describe('Swg Controller: class', function () {
 					expect(subject.resolveUser.calledWith(subject.NEW_USER, MOCK_RESULT)).to.be.true;
 					mockResponseComplete.then(() => {
 						expect(SwgController.trackEvent.calledTwice).to.be.true;
-						expect(subject.onwardSubscribedJourney.calledOnce).to.be.true;
+						expect(subject.handlers.onResolvedSubscribe.calledOnce).to.be.true;
 						expect(SwgController.trackEvent.calledWith(sinon.match({ action: 'confirmation' }))).to.be.true;
 						subject.resolveUser.restore();
 						subject.subscribeButtons.disableButtons.restore();
-						subject.onwardSubscribedJourney.restore();
+						subject.handlers.onResolvedSubscribe.restore();
 						done();
 					});
 				});

--- a/test/client/swg-controller/custom-handlers.spec.js
+++ b/test/client/swg-controller/custom-handlers.spec.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { JSDOM } = require('../mocks/document');
+const SwgClient = require('../mocks/swg-client');
+const SwgController = require('../../../src/client/swg-controller');
+
+describe('Swg Controller: custom handlers', function () {
+	let swgClient;
+	let subject;
+	let customHandlers;
+
+	beforeEach(() => {
+		const jsdom = new JSDOM();
+		global.CustomEvent = jsdom.window.CustomEvent;
+		global.document = jsdom.window.document;
+		global.window = jsdom.window;
+		swgClient = new SwgClient();
+		customHandlers = {
+			onResolvedEntitlements: sinon.stub(),
+			onResolvedSubscribe: sinon.stub()
+		};
+		subject = new SwgController(swgClient, { handlers: customHandlers });
+		sinon.stub(SwgController, 'signal');
+		sinon.stub(SwgController, 'trackEvent');
+	});
+
+	afterEach(() => {
+		delete global.CustomEvent;
+		delete global.document;
+		delete global.window;
+		SwgController.signal.restore();
+			SwgController.trackEvent.restore();
+	});
+
+	it('after successful subscribe, call options.handlers.onResolvedSubscribe()', function (done) {
+		const mockResponseComplete = Promise.resolve();
+		const MOCK_RESULT = { mock: 'swg-result', complete: () => mockResponseComplete };
+		const subPromise = Promise.resolve(MOCK_RESULT);
+		const resolveUserPromise = Promise.resolve();
+
+		sinon.stub(subject, 'resolveUser').returns(resolveUserPromise);
+		subject.onSubscribeResponse(subPromise);
+
+		subject.init();
+		subPromise.then(() => {
+			expect(SwgController.signal.calledWith('onSubscribeReturn', MOCK_RESULT)).to.be.true;
+			expect(SwgController.trackEvent.calledOnce).to.be.true;
+			expect(SwgController.trackEvent.calledWith(sinon.match({ action: 'success' }))).to.be.true;
+			resolveUserPromise.then(() => {
+				expect(subject.resolveUser.calledWith(subject.NEW_USER, MOCK_RESULT)).to.be.true;
+				mockResponseComplete.then(() => {
+					expect(SwgController.trackEvent.calledTwice).to.be.true;
+					expect(customHandlers.onResolvedSubscribe.calledOnce).to.be.true;
+					subject.resolveUser.restore();
+					done();
+				});
+			});
+		})
+		.catch(done);
+	});
+
+	it('after resolving a users entitlements at init(), call options.handlers.onResolvedEntitlments()', function (done) {
+		const checkEntitlementsPromise = Promise.resolve({ granted: true });
+		const resolveUserPromise = Promise.resolve();
+		sinon.stub(subject, 'checkEntitlements').resolves(checkEntitlementsPromise);
+		sinon.stub(subject, 'resolveUser').returns(resolveUserPromise);
+
+		subject.init();
+		checkEntitlementsPromise.then(() => {
+			resolveUserPromise.then(() => {
+				expect(customHandlers.onResolvedEntitlements.calledOnce).to.be.true;
+				subject.resolveUser.restore();
+				subject.checkEntitlements.restore();
+				done();
+			})
+			.catch(done);
+		})
+		.catch(done);
+	});
+
+});


### PR DESCRIPTION
In the login app we will not want to "prompt user to login" as
they are already on the login page.

This feature allows a custom handler to be passed into swg on
construction that will be called instead, or default to existing
behaviour.

 🐿 v2.7.0