### PR TITLE
update swg controller to handle entitlements prompt on article use case

### DIFF
--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -23,7 +23,7 @@ module.exports = class SwgController {
 			onFlowStarted: this.onFlowStarted.bind(this),
 			onSubscribeResponse: this.onSubscribeResponse.bind(this),
 			onLoginRequest: this.onLoginRequest.bind(this),
-			onResolvedEntitlements: this.defaultOnwardEntitledJourney.bind(this),
+			onResolvedEntitlements: options.customOnwardJourney ? () => { } : this.defaultOnwardEntitledJourney.bind(this),
 			onResolvedSubscribe: this.defaultOnwardSubscribedJourney.bind(this)
 		}, options.handlers);
 
@@ -294,7 +294,7 @@ module.exports = class SwgController {
 	 * If we need to gather user consent, then go via the POST_SUBSCRIBE_URL
 	 * @param {object} result - the result of the Google entitlements check
 	 */
-	defaultOnwardEntitledJourney (result={}) {
+	getEntitledOnwardJourneyProps (result = {}) {
 		const uuid = browser.getContentUuidFromUrl();
 		const consentHref = this.POST_SUBSCRIBE_URL + (uuid ? '&ft-content-uuid=' + uuid : '');
 		const contentHref = uuid ? `https://www.ft.com/content/${uuid}` : 'https://www.ft.com';
@@ -307,7 +307,7 @@ module.exports = class SwgController {
 			this.overlay.showActivity();
 			ev.preventDefault();
 			this.resolveUser(this.ENTITLED_USER, result.json)
-				.then(({ consentRequired=false, loginRequired=false }={}) => {
+				.then(({ consentRequired = false, loginRequired = false } = {}) => {
 					/* set onward journey */
 					if (loginRequired) {
 						this.overlay.hideActivity();
@@ -332,6 +332,11 @@ module.exports = class SwgController {
 			callback: onLoginCtaClick
 		};
 
+		return logMeInCta;
+	}
+
+	defaultOnwardEntitledJourney (result = {}) {
+		const logMeInCta = this.getEntitledOnwardJourneyProps(result);
 		this.overlay.show('<h3>You\'ve got a subscription on FT.com</h3><p>It looks like you are already subscribed to FT.com via Google</p>', logMeInCta);
 	}
 

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -793,12 +793,18 @@ describe('Swg Controller: class', function () {
 		});
 
 		describe('.defaultOnwardEntitledJourney()', function () {
-
 			it('Will show an overlay message informing the user of their SwG subscription, with a login prompt', function () {
 				subject.defaultOnwardEntitledJourney();
 				expect(overlayStub.calledWith(sinon.match('It looks like you are already subscribed to FT.com via Google'))).to.be.true;
 			});
+		});
 
+		describe('.getEntitledOnwardJourneyProps()', function () {
+			it('Returns an object containing the relevant properties', function () {
+				subject.getEntitledOnwardJourneyProps();
+				expect(subject.getEntitledOnwardJourneyProps()).to.contain.keys('copy', 'href', 'callback');
+				expect(subject.getEntitledOnwardJourneyProps().callback).to.be.a('function');
+			});
 			context('upon user clicking the login cta', function () {
 				let invokeCtaClickCallback;
 				let mockEvent;
@@ -861,7 +867,9 @@ describe('Swg Controller: class', function () {
 					context('login still required', function () {
 
 						it('show prompt login message if still required', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: true });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: true
+							});
 							sandbox.stub(subject.overlay, 'hideActivity');
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
@@ -873,7 +881,9 @@ describe('Swg Controller: class', function () {
 						});
 
 						it('login link has correct location param default', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: true });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: true
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -884,7 +894,9 @@ describe('Swg Controller: class', function () {
 
 						it('login link has location param of requested content', async function () {
 							setHref('https://www.ft.com/barrier/trial?ft-content-uuid=12345&foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: true });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: true
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -897,7 +909,10 @@ describe('Swg Controller: class', function () {
 
 					context('consent required', function () {
 						it('redirects the browser to consent page (\/profile)', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: false, consentRequired: true });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: false,
+								consentRequired: true
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -909,7 +924,10 @@ describe('Swg Controller: class', function () {
 
 						it('redirects the browser to consent page (\/profile) with ft-content-uuid of requested content', async function () {
 							setHref('https://www.ft.com/content/12345?foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: false, consentRequired: true });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: false,
+								consentRequired: true
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -923,7 +941,10 @@ describe('Swg Controller: class', function () {
 					context('no consent or login required', function () {
 
 						it('redirect to ft.com homepage by default', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: false, consentRequired: false });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: false,
+								consentRequired: false
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -935,7 +956,10 @@ describe('Swg Controller: class', function () {
 
 						it('redirect to requested content from ft-content-uuid paramrter', async function () {
 							setHref('https://www.ft.com/barrier/trial?ft-content-uuid=12345&foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: false, consentRequired: false });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: false,
+								consentRequired: false
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -947,7 +971,10 @@ describe('Swg Controller: class', function () {
 
 						it('redirect to requested content if on barrier page', async function () {
 							setHref('https://www.ft.com/content/12345?foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({ loginRequired: false, consentRequired: false });
+							const RESOLVE_USER_RESULT = Promise.resolve({
+								loginRequired: false,
+								consentRequired: false
+							});
 							resolveUserStub.returns(RESOLVE_USER_RESULT);
 
 							subject.defaultOnwardEntitledJourney();
@@ -960,12 +987,9 @@ describe('Swg Controller: class', function () {
 					});
 
 				});
-
-
 			});
 
 		});
-
 
 		describe('.defaultOnwardSubscribedJourney()', function () {
 


### PR DESCRIPTION
# Feature Description
Google have asked that we add entitlements checking to Article pages. 
Currently the `defaultOnwardsEntitlementsJourney` function in `n-swg` defines the properties for the 'you already have an account via google' overlay and then shows the overlay. 
We want to show this message on articles and will use `n-messaging-client` to do that, however to implement this properly in `n-messaging-client` we need to use `o-banner` rather than the overlay created by `n-swg`.
This PR splits out the `defaultOnwardsEntitlementsJourney` function into two:
 - `getEntitledOnwardJourneyProps` which defines and returns the properties for the button on the entitlements prompt. This can be used agnostic of whether the `n-swg` overlay or an `n-messaging-client` banner is used as the format for the prompt 
 - `defaultOnwardsEntitlementsJourney` - uses the properties returned by `getEntitledOnwardJourneyProps` to render the `n-swg` overlay

# Link to Ticket / Card:
https://trello.com/c/WgGJ6ueb

## Image
![image](https://user-images.githubusercontent.com/17846996/44850603-a8439880-ac55-11e8-923d-7b22f8f7d811.png)

## To do

- [x] button styling per SIWG - being covered in different card - https://trello.com/c/WCQm5hVx
- [x] write test for new function

## Related PRs

- https://github.com/Financial-Times/n-messaging-client/pull/111
