### PR TITLE
Update entitled journey to login or create account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,10 @@ a11y: demo-build
 
 test: verify
 	make unit-test
-	make a11y-demo
 
 unit-test:
 	mocha test/client --recursive --require test/client/setup
 
-a11y-demo:
+smoke:
 	export TEST_URL=http://localhost:5050; \
 	make a11y
-
-smoke:
-	n-test smoke --host http://localhost:5050

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-sass": "^4.7.2",
     "nodemon": "^1.14.12",
     "npm-prepublish": "^1.2.3",
-    "pa11y-ci": "^1.3.1",
+    "pa11y-ci": "^2.1.1",
     "proxyquire": "^1.8.0",
     "request": "^2.83.0",
     "sinon": "^4.4.2"

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -246,7 +246,6 @@ module.exports = class SwgController {
 
 		return new Promise((resolve, reject) => {
 
-			return resolve();
 			smartFetch.fetch(endpoint, {
 				method: 'POST',
 				credentials: 'include',

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -148,9 +148,7 @@ module.exports = class SwgController {
 				/* when user clicks SwG "continue" cta */
 				response.complete().then(() => {
 					/* track confirmation event */
-					this.track({ action: 'google-confirmed', context: {
-						// TODO subscriptionId: response.subscriptionId
-					}});
+					this.track({ action: 'google-confirmed' });
 					/* trigger onward journey */
 					this.handlers.onResolvedSubscribe(res);
 				});
@@ -166,7 +164,6 @@ module.exports = class SwgController {
 					/* track failure event */
 					this.track({ action: 'failure', context: {
 						stage: 'user-resolution'
-						// TODO subscriptionId: response.subscriptionId
 					}});
 					/* trigger onward journey */
 					this.onwardSubscriptionErrorJourney();
@@ -365,9 +362,7 @@ module.exports = class SwgController {
 				// Update Goggle to say we've completed
 				await response.complete();
 
-				this.track({ action: 'google-confirmed', context: {
-					// TODO subscriptionId: response.subscriptionId
-				}});
+				this.track({ action: 'google-confirmed' });
 
 				// Redirect the browser
 				browser.redirectTo(consentHref);

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -13,8 +13,10 @@ module.exports = class SwgController {
 		this.swgClient = swgClient;
 		this.manualInitDomain = options.manualInitDomain;
 		this.MAX_RETRIES = 2;
-		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || (options.sandbox ? 'https://api-t.ft.com/commerce/v1/swg/subscriptions' : 'https://api.ft.com/commerce/v1/swg/subscriptions');
-		this.M_SWG_ENTITLED_SUCCESS_ENDPOINT = options.M_SWG_ENTITLED_SUCCESS_ENDPOINT || (options.sandbox ? 'https://api-t.ft.com/commerce/v1/swg/subscriptions/entitlementsCheck' : 'https://api.ft.com/commerce/v1/swg/subscriptions/entitlementsCheck');
+		this.M_SWG_URL = options.sandbox ? 'https://api-t.ft.com/commerce/v1/swg' : 'https://api.ft.com/commerce/v1/swg';
+		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/subscriptions`;
+		this.M_SWG_ENTITLED_SUCCESS_ENDPOINT = options.M_SWG_ENTITLED_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/subscriptions/entitlementsCheck`;
+		this.M_SWG_ACCOUNT_CHECK = options.M_SWG_ACCOUNT_CHECK || `${this.M_SWG_URL}/subscriptions/deferred_account`;
 		this.POST_SUBSCRIBE_URL = options.POST_SUBSCRIBE_URL || 'https://www.ft.com/profile?splash=swg_checkout';
 		this.NEW_SWG_SUB_COOKIE = 'FTSwgNewSubscriber';
 		this.handlers = Object.assign({
@@ -23,7 +25,7 @@ module.exports = class SwgController {
 			onFlowStarted: this.onFlowStarted.bind(this),
 			onSubscribeResponse: this.onSubscribeResponse.bind(this),
 			onLoginRequest: this.onLoginRequest.bind(this),
-			onResolvedEntitlements: options.customOnwardJourney ? () => { } : this.defaultOnwardEntitledJourney.bind(this),
+			onResolvedEntitlements: this.defaultOnwardEntitledJourney.bind(this),
 			onResolvedSubscribe: this.defaultOnwardSubscribedJourney.bind(this)
 		}, options.handlers);
 
@@ -290,54 +292,82 @@ module.exports = class SwgController {
 	}
 
 	/**
-	 * User is entitled to content. Prompt them to allow us to log them.
-	 * If we need to gather user consent, then go via the POST_SUBSCRIBE_URL
+	 * Check to see if there is an account associated with the given subscriptionToken
+	 * @param {string} subscriptionToken From Googles entitlement check
+	 * @return {boolean}
+	 */
+	async hasAccount (subscriptionToken) {
+		try {
+			const result = await smartFetch.fetch(`${this.M_SWG_ACCOUNT_CHECK}?subscription_token=${subscriptionToken}`, {
+				method: 'GET',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' }
+			});
+			if (result.active) {
+				return true;
+			}
+			return false;
+		} catch (e) {
+			// Fail silently
+			return false;
+		}
+	}
+
+	/**
+	 * User is entitled to content but does not have an account with the FT
+	 * Run the completeDeferredAccountCreation journey to create them an account
 	 * @param {object} result - the result of the Google entitlements check
 	 */
-	getEntitledOnwardJourneyProps (result = {}) {
+	async defaultOnwardEntitledJourney (result = {}) {
 		const uuid = browser.getContentUuidFromUrl();
 		const consentHref = this.POST_SUBSCRIBE_URL + (uuid ? '&ft-content-uuid=' + uuid : '');
 		const contentHref = uuid ? `https://www.ft.com/content/${uuid}` : 'https://www.ft.com';
-		const loginCta = {
-			copy: 'Go to the FT login page',
-			href: browser.generateLoginUrl()
-		};
 
-		const onLoginCtaClick = (ev) => {
-			this.overlay.showActivity();
-			ev.preventDefault();
-			this.resolveUser(this.ENTITLED_USER, result.json)
-				.then(({ consentRequired = false, loginRequired = false } = {}) => {
-					/* set onward journey */
-					if (loginRequired) {
-						this.overlay.hideActivity();
-						this.overlay.show('<h3>Sorry</h3><p>We couldn’t log you in automatically</p>', loginCta);
-					} else if (consentRequired) {
-						browser.redirectTo(consentHref);
-					} else {
-						browser.redirectTo(contentHref);
-					}
-				})
-				.catch(err => {
-					this.overlay.hideActivity();
-					/* signal error */
-					events.signalError(err);
-					this.overlay.show('<h3>Sorry</h3><p>We couldn’t log you in automatically</p>', loginCta);
-				});
-		};
+		try {
+			const accountLookupPromise = this.hasAccount(result.subscriptionToken);
+			const account = await this.swgClient.waitForSubscriptionLookup(accountLookupPromise);
 
-		const logMeInCta = {
-			copy: 'Login and continue',
-			href: loginCta.href, // fallback href
-			callback: onLoginCtaClick
-		};
+			if (account) {
+				// The users account exists so lets log them in
 
-		return logMeInCta;
-	}
+				// Tell the user that we are going to log them in
+				await this.swgClient.showLoginNotification();
 
-	defaultOnwardEntitledJourney (result = {}) {
-		const logMeInCta = this.getEntitledOnwardJourneyProps(result);
-		this.overlay.show('<h3>You\'ve got a subscription on FT.com</h3><p>It looks like you are already subscribed to FT.com via Google</p>', logMeInCta);
+				// Redirect the browser
+				browser.redirectTo(contentHref);
+			} else {
+				// The users account was not found so lets make them one
+
+				// Popup the Google deferred account creation
+				const response = await this.swgClient.completeDeferredAccountCreation(
+					{entitlements: result.entitlements, consent: true}
+				);
+
+				// Fix data structure to be inline with SubscriptionResponse
+				// https://developers.google.com/news/subscribe/reference/subscription-response
+				// This can be removed once this PR has been merged
+				// https://github.com/subscriptions-project/swg-js/pull/418/files
+				if (response.purchaseData && response.purchaseData.raw && response.purchaseData.raw.data) {
+					response.purchaseData.signature = response.purchaseData.raw.signature;
+					response.purchaseData.raw = response.purchaseData.raw.data;
+				}
+
+				// Call Membership to create the user
+				await this.resolveUser(this.NEW_USER, response);
+
+				// Update Goggle to say we've completed
+				await response.complete();
+
+				this.track({ action: 'google-confirmed', context: {
+					// TODO subscriptionId: response.subscriptionId
+				}});
+
+				// Redirect the browser
+				browser.redirectTo(consentHref);
+			}
+		} catch (err) {
+			events.signalError(err);
+		}
 	}
 
 	/**

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -330,8 +330,15 @@ module.exports = class SwgController {
 			if (account) {
 				// The users account exists so lets log them in
 
+				// Resolve the user and log them in
+				const LoginPromise = this.resolveUser(this.ENTITLED_USER, result);
+
 				// Tell the user that we are going to log them in
-				await this.swgClient.showLoginNotification();
+				const showLoginPromise = this.swgClient.showLoginNotification();
+
+				// Await the promises
+				await LoginPromise;
+				await showLoginPromise;
 
 				// Redirect the browser
 				browser.redirectTo(contentHref);

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -245,7 +245,6 @@ module.exports = class SwgController {
 			: JSON.stringify({ createSession, swg: swgResponse });
 
 		return new Promise((resolve, reject) => {
-
 			smartFetch.fetch(endpoint, {
 				method: 'POST',
 				credentials: 'include',
@@ -346,10 +345,12 @@ module.exports = class SwgController {
 					{ entitlements: result.entitlements, consent: true }
 				);
 
-				// Fix data structure to be inline with SubscriptionResponse
-				// https://developers.google.com/news/subscribe/reference/subscription-response
-				// This can be removed once this PR has been merged
-				// https://github.com/subscriptions-project/swg-js/pull/418/files
+				/**
+				 * Fix data structure to be inline with SubscriptionResponse
+				 * https://developers.google.com/news/subscribe/reference/subscription-response
+				 * This can be removed once this PR has been merged
+				 * https://github.com/subscriptions-project/swg-js/pull/418/files
+				 */
 				if (response.purchaseData && response.purchaseData.raw && response.purchaseData.raw.data) {
 					response.purchaseData.signature = response.purchaseData.raw.signature;
 					response.purchaseData.raw = response.purchaseData.raw.data;

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -13,10 +13,10 @@ module.exports = class SwgController {
 		this.swgClient = swgClient;
 		this.manualInitDomain = options.manualInitDomain;
 		this.MAX_RETRIES = 2;
-		this.M_SWG_URL = options.sandbox ? 'https://api-t.ft.com/commerce/v1/swg' : 'https://api.ft.com/commerce/v1/swg';
-		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/subscriptions`;
-		this.M_SWG_ENTITLED_SUCCESS_ENDPOINT = options.M_SWG_ENTITLED_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/subscriptions/entitlementsCheck`;
-		this.M_SWG_ACCOUNT_CHECK = options.M_SWG_ACCOUNT_CHECK || `${this.M_SWG_URL}/subscriptions/deferred_account`;
+		this.M_SWG_URL = options.sandbox ? 'https://api-t.ft.com/commerce' : 'https://api.ft.com/commerce';
+		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/v1/swg/subscriptions`;
+		this.M_SWG_ENTITLED_SUCCESS_ENDPOINT = options.M_SWG_ENTITLED_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/v1/swg/subscriptions/entitlementsCheck`;
+		this.M_SWG_ACCOUNT_CHECK = options.M_SWG_ACCOUNT_CHECK || `${this.M_SWG_URL}/deferred-account`;
 		this.POST_SUBSCRIBE_URL = options.POST_SUBSCRIBE_URL || 'https://www.ft.com/profile?splash=swg_checkout';
 		this.NEW_SWG_SUB_COOKIE = 'FTSwgNewSubscriber';
 		this.handlers = Object.assign({

--- a/test/client/mocks/swg-client.js
+++ b/test/client/mocks/swg-client.js
@@ -46,4 +46,16 @@ module.exports = class SwgClient {
 		return true;
 	}
 
+	waitForSubscriptionLookup () {
+		return Promise.resolve(true);
+	}
+
+	showLoginNotification () {
+		return Promise.resolve(true);
+	}
+
+	completeDeferredAccountCreation () {
+		return Promise.resolve(true);
+	}
+
 };

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -803,12 +803,14 @@ describe('Swg Controller: class', function () {
 			it('should log the user in of they have an account', async () => {
 				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.resolve(true));
 				sandbox.spy(swgClient, 'showLoginNotification');
+				sandbox.spy(subject, 'resolveUser');
 
 				await subject.defaultOnwardEntitledJourney({
 					subscriptionToken: 'test'
 				});
 
 				expect(swgClient.showLoginNotification.calledOnce).to.be.true;
+				expect(subject.resolveUser.calledOnce).to.be.true;
 			});
 
 			it('should create the user if they don\'t have an account', async () => {

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -789,13 +789,18 @@ describe('Swg Controller: class', function () {
 		});
 
 		describe('.defaultOnwardEntitledJourney()', function () {
+			const entitlements = {
+				entitlements: {
+					entitlements: [
+						{subscriptionToken: 'test'}
+					]
+				}
+			};
 
 			it('should check if the entitled user has an account or not', () => {
 				sandbox.spy(subject, 'hasAccount');
 
-				subject.defaultOnwardEntitledJourney({
-					subscriptionToken: 'test'
-				});
+				subject.defaultOnwardEntitledJourney(entitlements);
 
 				expect(subject.hasAccount.calledWith('test')).to.be.true;
 			});
@@ -805,9 +810,7 @@ describe('Swg Controller: class', function () {
 				sandbox.spy(swgClient, 'showLoginNotification');
 				sandbox.spy(subject, 'resolveUser');
 
-				await subject.defaultOnwardEntitledJourney({
-					subscriptionToken: 'test'
-				});
+				await subject.defaultOnwardEntitledJourney(entitlements);
 
 				expect(swgClient.showLoginNotification.calledOnce).to.be.true;
 				expect(subject.resolveUser.calledOnce).to.be.true;
@@ -818,9 +821,7 @@ describe('Swg Controller: class', function () {
 				sandbox.spy(swgClient, 'completeDeferredAccountCreation');
 				sandbox.spy(subject, 'resolveUser');
 
-				await subject.defaultOnwardEntitledJourney({
-					subscriptionToken: 'test'
-				});
+				await subject.defaultOnwardEntitledJourney(entitlements);
 
 				expect(swgClient.completeDeferredAccountCreation.calledOnce).to.be.true;
 				expect(subject.resolveUser.calledOnce).to.be.true;
@@ -830,9 +831,7 @@ describe('Swg Controller: class', function () {
 				sinon.spy(utils.events, 'signalError');
 				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.reject(false));
 
-				await subject.defaultOnwardEntitledJourney({
-					subscriptionToken: 'test'
-				});
+				await subject.defaultOnwardEntitledJourney(entitlements);
 
 				expect(utils.events.signalError.calledOnce).to.be.true;
 			});

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -768,9 +768,7 @@ describe('Swg Controller: class', function () {
 
 	context('Onward journeys', function () {
 		let subject;
-		let overlayStub;
 		let redirectStub;
-		let resolveUserStub;
 		let windowLocation;
 
 		function setHref (href) {
@@ -779,13 +777,9 @@ describe('Swg Controller: class', function () {
 		}
 
 		beforeEach(() => {
-			windowLocation = { search: '', href: '' };
 			subject = new SwgController(swgClient);
 			subject.init();
-			redirectStub = sandbox.stub(utils.browser, 'redirectTo');
-			overlayStub = sandbox.stub(subject.overlay, 'show');
-			resolveUserStub = sandbox.stub(subject, 'resolveUser').resolves({});
-			sandbox.stub(utils.browser, 'getWindowLocation').returns(windowLocation);
+			sandbox.stub(utils.browser, 'redirectTo');
 		});
 
 		afterEach(() => {
@@ -793,202 +787,51 @@ describe('Swg Controller: class', function () {
 		});
 
 		describe('.defaultOnwardEntitledJourney()', function () {
-			it('Will show an overlay message informing the user of their SwG subscription, with a login prompt', function () {
-				subject.defaultOnwardEntitledJourney();
-				expect(overlayStub.calledWith(sinon.match('It looks like you are already subscribed to FT.com via Google'))).to.be.true;
-			});
-		});
 
-		describe('.getEntitledOnwardJourneyProps()', function () {
-			it('Returns an object containing the relevant properties', function () {
-				subject.getEntitledOnwardJourneyProps();
-				expect(subject.getEntitledOnwardJourneyProps()).to.contain.keys('copy', 'href', 'callback');
-				expect(subject.getEntitledOnwardJourneyProps().callback).to.be.a('function');
-			});
-			context('upon user clicking the login cta', function () {
-				let invokeCtaClickCallback;
-				let mockEvent;
+			it('should check if the entitled user has an account or not', () => {
+				sandbox.spy(subject, 'hasAccount');
 
-				beforeEach(() => {
-					mockEvent = {
-						preventDefault: sandbox.stub()
-					};
-					overlayStub.callsFake((copy, cta) => {
-						invokeCtaClickCallback = cta.callback;
-					});
+				subject.defaultOnwardEntitledJourney({
+					subscriptionToken: 'test'
 				});
 
-				afterEach(() => {
-					invokeCtaClickCallback = null;
-				});
-
-				it('will showActivity in modal', function () {
-					sandbox.stub(subject.overlay, 'showActivity');
-					subject.defaultOnwardEntitledJourney();
-					invokeCtaClickCallback(mockEvent);
-					expect(subject.overlay.showActivity.calledOnce).to.be.true;
-				});
-
-				it('will preventDefault on event', function () {
-					subject.defaultOnwardEntitledJourney();
-					invokeCtaClickCallback(mockEvent);
-					expect(mockEvent.preventDefault.calledOnce).to.be.true;
-				});
-
-				it('will attempt to resolveUser', function () {
-					subject.defaultOnwardEntitledJourney();
-					invokeCtaClickCallback(mockEvent);
-					expect(resolveUserStub.calledOnce).to.be.true;
-				});
-
-				describe('on user resolution failure', function () {
-
-					it('should show a message prompting user to try again via login', async function () {
-						sandbox.stub(utils.events, 'signalError');
-						const swallow = sandbox.stub();
-						const MOCK_ERR = new Error('bad');
-						const RESOLVE_USER_RESULT = Promise.reject(MOCK_ERR);
-						sandbox.stub(subject.overlay, 'hideActivity');
-						resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-						subject.defaultOnwardEntitledJourney();
-						invokeCtaClickCallback(mockEvent);
-						await RESOLVE_USER_RESULT.catch(swallow);
-
-						expect(subject.overlay.hideActivity.calledOnce).to.be.true;
-						expect(utils.events.signalError.calledWith(MOCK_ERR)).to.be.true;
-						expect(overlayStub.calledWith(sinon.match('We couldn’t log you in automatically'))).to.be.true;
-					});
-
-				});
-
-				describe('on successful user resolution', function () {
-
-					context('login still required', function () {
-
-						it('show prompt login message if still required', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: true
-							});
-							sandbox.stub(subject.overlay, 'hideActivity');
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-							expect(subject.overlay.hideActivity.calledOnce).to.be.true;
-							expect(overlayStub.calledWith(sinon.match('We couldn’t log you in automatically'))).to.be.true;
-						});
-
-						it('login link has correct location param default', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: true
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-							expect(overlayStub.getCall(0).args[1].href).to.equal('https://www.ft.com/login?socialEnabled=true');
-						});
-
-						it('login link has location param of requested content', async function () {
-							setHref('https://www.ft.com/barrier/trial?ft-content-uuid=12345&foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: true
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-							expect(overlayStub.getCall(0).args[1].href).to.equal('https://www.ft.com/login?socialEnabled=true&location=https%3A%2F%2Fwww.ft.com%2Fcontent%2F12345');
-						});
-
-					});
-
-					context('consent required', function () {
-						it('redirects the browser to consent page (\/profile)', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: false,
-								consentRequired: true
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-
-							expect(redirectStub.calledWith(subject.POST_SUBSCRIBE_URL)).to.be.true;
-						});
-
-						it('redirects the browser to consent page (\/profile) with ft-content-uuid of requested content', async function () {
-							setHref('https://www.ft.com/content/12345?foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: false,
-								consentRequired: true
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-
-							expect(redirectStub.calledWith(subject.POST_SUBSCRIBE_URL + '&ft-content-uuid=12345')).to.be.true;
-						});
-					});
-
-					context('no consent or login required', function () {
-
-						it('redirect to ft.com homepage by default', async function () {
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: false,
-								consentRequired: false
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-
-							expect(redirectStub.calledWith('https://www.ft.com')).to.be.true;
-						});
-
-						it('redirect to requested content from ft-content-uuid paramrter', async function () {
-							setHref('https://www.ft.com/barrier/trial?ft-content-uuid=12345&foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: false,
-								consentRequired: false
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-
-							expect(redirectStub.calledWith('https://www.ft.com/content/12345')).to.be.true;
-						});
-
-						it('redirect to requested content if on barrier page', async function () {
-							setHref('https://www.ft.com/content/12345?foo=bar');
-							const RESOLVE_USER_RESULT = Promise.resolve({
-								loginRequired: false,
-								consentRequired: false
-							});
-							resolveUserStub.returns(RESOLVE_USER_RESULT);
-
-							subject.defaultOnwardEntitledJourney();
-							invokeCtaClickCallback(mockEvent);
-							await RESOLVE_USER_RESULT;
-
-							expect(redirectStub.calledWith('https://www.ft.com/content/12345')).to.be.true;
-						});
-
-					});
-
-				});
+				expect(subject.hasAccount.calledWith('test')).to.be.true;
 			});
 
+			it('should log the user in of they have an account', async () => {
+				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.resolve(true));
+				sandbox.spy(swgClient, 'showLoginNotification');
+
+				await subject.defaultOnwardEntitledJourney({
+					subscriptionToken: 'test'
+				});
+
+				expect(swgClient.showLoginNotification.calledOnce).to.be.true;
+			});
+
+			it('should create the user if they don\'t have an account', async () => {
+				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.resolve(false));
+				sandbox.spy(swgClient, 'completeDeferredAccountCreation');
+				sandbox.spy(subject, 'resolveUser');
+
+				await subject.defaultOnwardEntitledJourney({
+					subscriptionToken: 'test'
+				});
+
+				expect(swgClient.completeDeferredAccountCreation.calledOnce).to.be.true;
+				expect(subject.resolveUser.calledOnce).to.be.true;
+			});
+
+			it('should signal an error if one happens', async () => {
+				sinon.spy(utils.events, 'signalError');
+				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.reject(false));
+
+				await subject.defaultOnwardEntitledJourney({
+					subscriptionToken: 'test'
+				});
+
+				expect(utils.events.signalError.calledOnce).to.be.true;
+			});
 		});
 
 		describe('.defaultOnwardSubscribedJourney()', function () {

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -777,9 +777,11 @@ describe('Swg Controller: class', function () {
 		}
 
 		beforeEach(() => {
+			windowLocation = { search: '', href: '' };
 			subject = new SwgController(swgClient);
 			subject.init();
-			sandbox.stub(utils.browser, 'redirectTo');
+			redirectStub = sandbox.stub(utils.browser, 'redirectTo');
+			sandbox.stub(utils.browser, 'getWindowLocation').returns(windowLocation);
 		});
 
 		afterEach(() => {

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -798,7 +798,7 @@ describe('Swg Controller: class', function () {
 			};
 
 			it('should check if the entitled user has an account or not', () => {
-				sandbox.spy(subject, 'hasAccount');
+				sandbox.stub(subject, 'hasAccount').returns(Promise.resolve(true));
 
 				subject.defaultOnwardEntitledJourney(entitlements);
 
@@ -806,6 +806,7 @@ describe('Swg Controller: class', function () {
 			});
 
 			it('should log the user in of they have an account', async () => {
+				sandbox.stub(subject, 'hasAccount').returns(Promise.resolve(true));
 				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.resolve(true));
 				sandbox.spy(swgClient, 'showLoginNotification');
 				sandbox.spy(subject, 'resolveUser');
@@ -817,6 +818,7 @@ describe('Swg Controller: class', function () {
 			});
 
 			it('should create the user if they don\'t have an account', async () => {
+				sandbox.stub(subject, 'hasAccount').returns(Promise.resolve(false));
 				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.resolve(false));
 				sandbox.spy(swgClient, 'completeDeferredAccountCreation');
 				sandbox.spy(subject, 'resolveUser');
@@ -828,6 +830,7 @@ describe('Swg Controller: class', function () {
 			});
 
 			it('should signal an error if one happens', async () => {
+				sandbox.stub(subject, 'hasAccount').returns(Promise.resolve(true));
 				sinon.spy(utils.events, 'signalError');
 				sandbox.stub(swgClient, 'waitForSubscriptionLookup').returns(Promise.reject(false));
 


### PR DESCRIPTION
**Description**
Google have fleshed out the sign-in and account creation UI for SwG. This PR takes advantage of this UI for our default onward journey.

This is a breaking change as it removes the `getEntitledOnwardJourneyProps` functionality as I no longer think this is needed.

Still to do:
-  Check that this hooks up correctly with the new membership endpoint

**Ticket**
https://trello.com/c/bMZCBFwv/646-swg-deferred-account-creation

**Screenshots**
TBD