### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/Financial-Times/n-swg#readme",
   "dependencies": {},
   "devDependencies": {
-    "@financial-times/n-gage": "3.5.0",
+    "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-internal-tool": "^2.2.2",
     "@financial-times/n-logger": "^5.6.3",
     "@financial-times/n-test": "^1.0.1",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.