### PR TITLE
Update setOnSubscribeResponse -> setOnPaymentResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As well as containing the source code for `n-swg` this repo acts as a documentat
 - [JSON-LD Markup](#json-ld-markup)
 - [SwG on AMP](#swg-on-amp)
 - [SwG on mobile apps](#swg-on-mobile-apps)
-- [SKUs](#skus) 
+- [SKUs](#skus)
 
 ## What is SwG?
 
@@ -157,7 +157,7 @@ successful subscription confirmation */
 },
 
 handlers: {
-	onSubscribeResponse: (args) => console.log('Welcome to the FT')
+	onPaymentResponse: (args) => console.log('Welcome to the FT')
 }
 /* [optional] An object containing custom callback functions. See the
 SwgController constructor for available handlers */

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -23,7 +23,7 @@ module.exports = class SwgController {
 			onEntitlementsResponse: this.onEntitlementsResponse.bind(this),
 			onFlowCanceled: this.onFlowCanceled.bind(this),
 			onFlowStarted: this.onFlowStarted.bind(this),
-			onSubscribeResponse: this.onSubscribeResponse.bind(this),
+			onPaymentResponse: this.onPaymentResponse.bind(this),
 			onLoginRequest: this.onLoginRequest.bind(this),
 			onResolvedEntitlements: this.defaultOnwardEntitledJourney.bind(this),
 			onResolvedSubscribe: this.defaultOnwardSubscribedJourney.bind(this)
@@ -32,7 +32,7 @@ module.exports = class SwgController {
 		/* bind handlers */
 		const mount = (name, handler) => this.swgClient[name] && handler && this.swgClient[name](handler);
 		mount('setOnEntitlementsResponse', this.handlers.onEntitlementsResponse);
-		mount('setOnSubscribeResponse', this.handlers.onSubscribeResponse);
+		mount('setOnPaymentResponse', this.handlers.onPaymentResponse);
 		mount('setOnLoginRequest', this.handlers.onLoginRequest);
 		mount('setOnFlowCanceled', this.handlers.onFlowCanceled);
 		mount('setOnFlowStarted', this.handlers.onFlowStarted);
@@ -133,7 +133,7 @@ module.exports = class SwgController {
 	 * Upon SwG subscription response. Resolve the user and set onward journey.
 	 * @param {promise} subPromise - as returned by SwG
 	 */
-	onSubscribeResponse (subPromise) {
+	onPaymentResponse (subPromise) {
 		return subPromise.then((response) => {
 			/* disable any buttons */
 			if (this.subscribeButtons) this.subscribeButtons.disableButtons();

--- a/test/client/mocks/swg-client.js
+++ b/test/client/mocks/swg-client.js
@@ -18,7 +18,7 @@ module.exports = class SwgClient {
 		return true;
 	}
 
-	setOnSubscribeResponse () {
+	setOnPaymentResponse () {
 		return true;
 	}
 

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -43,7 +43,7 @@ describe('Swg Controller: class', function () {
 			expect(subject.alreadyInitialised).to.be.false;
 			expect(subject.handlers.onFlowCanceled).to.be.a('Function');
 			expect(subject.handlers.onFlowStarted).to.be.a('Function');
-			expect(subject.handlers.onSubscribeResponse).to.be.a('Function');
+			expect(subject.handlers.onPaymentResponse).to.be.a('Function');
 			expect(subject.handlers.onEntitlementsResponse).to.be.a('Function');
 			expect(subject.swgClient).to.deep.equal(swgClient);
 			expect(subject.overlay).to.be.an.instanceOf(utils.Overlay);
@@ -58,7 +58,7 @@ describe('Swg Controller: class', function () {
 				handlers: {
 					setOnFlowCanceled: () => 'canceled stub',
 					setOnFlowStarted: () => 'started stub',
-					onSubscribeResponse: () => 'stub',
+					onPaymentResponse: () => 'stub',
 					onSomeOtherThing: () => 'stub again'
 				},
 				M_SWG_SUB_SUCCESS_ENDPOINT: '/success',
@@ -68,7 +68,7 @@ describe('Swg Controller: class', function () {
 			expect(subject.manualInitDomain).to.equal(OPTIONS.manualInitDomain);
 			expect(subject.handlers.setOnFlowCanceled).to.equal(OPTIONS.handlers.setOnFlowCanceled);
 			expect(subject.handlers.setOnFlowStarted).to.equal(OPTIONS.handlers.setOnFlowStarted);
-			expect(subject.handlers.onSubscribeResponse).to.equal(OPTIONS.handlers.onSubscribeResponse);
+			expect(subject.handlers.onPaymentResponse).to.equal(OPTIONS.handlers.onPaymentResponse);
 			expect(subject.handlers.setOnEntitlementsResponse).to.equal(OPTIONS.handlers.setOnEntitlementsResponse);
 			expect(subject.handlers.onSomeOtherThing).to.equal(OPTIONS.handlers.onSomeOtherThing);
 			expect(subject.swgClient).to.deep.equal(swgClient);
@@ -77,11 +77,11 @@ describe('Swg Controller: class', function () {
 		});
 
 		it('binds event handlers', function () {
-			sandbox.stub(swgClient, 'setOnSubscribeResponse');
+			sandbox.stub(swgClient, 'setOnPaymentResponse');
 			sandbox.stub(swgClient, 'setOnEntitlementsResponse');
 
 			const subject = new SwgController(swgClient);
-			expect(swgClient.setOnSubscribeResponse.calledOnce).to.be.true;
+			expect(swgClient.setOnPaymentResponse.calledOnce).to.be.true;
 			expect(swgClient.setOnEntitlementsResponse.calledOnce).to.be.true;
 			expect(subject.swgClient).to.deep.equal(swgClient);
 	});
@@ -92,7 +92,7 @@ describe('Swg Controller: class', function () {
 
 		beforeEach(() => {
 			sandbox.stub(swgClient, 'init');
-			sandbox.stub(swgClient, 'setOnSubscribeResponse');
+			sandbox.stub(swgClient, 'setOnPaymentResponse');
 		});
 
 		it('does not setup swgClient if .alreadyInitialised', function () {
@@ -185,7 +185,7 @@ describe('Swg Controller: class', function () {
 
 	});
 
-	describe('.onSubscribeResponse() handler', function () {
+	describe('.onPaymentResponse() handler', function () {
 		let subject;
 
 		beforeEach(() => {
@@ -205,7 +205,7 @@ describe('Swg Controller: class', function () {
 			sandbox.stub(subject.subscribeButtons, 'disableButtons');
 			sandbox.spy(subject.handlers, 'onResolvedSubscribe');
 
-			await subject.onSubscribeResponse(subPromise);
+			await subject.onPaymentResponse(subPromise);
 			expect(global.document.cookie).to.include('FTSwgNewSubscriber');
 			expect(subject.subscribeButtons.disableButtons.calledOnce).to.be.true;
 			expect(utils.events.signal.calledWith('onSubscribeReturn', MOCK_RESULT)).to.be.true;
@@ -227,7 +227,7 @@ describe('Swg Controller: class', function () {
 			sandbox.stub(subject.subscribeButtons, 'disableButtons');
 			sandbox.spy(subject.handlers, 'onResolvedSubscribe');
 
-			await subject.onSubscribeResponse(subPromise);
+			await subject.onPaymentResponse(subPromise);
 			expect(subject.subscribeButtons.disableButtons.calledOnce).to.be.true;
 			expect(utils.events.signal.getCall(0).calledWith('onSubscribeReturn', MOCK_RESULT)).to.be.true;
 			expect(subject.track.getCall(0).calledWith(sinon.match({ action: 'success' }))).to.be.true;
@@ -248,7 +248,7 @@ describe('Swg Controller: class', function () {
 			};
 			const subPromise = Promise.reject(MOCK_ERROR);
 
-			await subject.onSubscribeResponse(subPromise);
+			await subject.onPaymentResponse(subPromise);
 			expect(utils.events.signal.calledWith('onError', { error: MOCK_ERROR, info: {} })).to.be.true;
 			expect(subject.track.calledOnce).to.be.true;
 			expect(subject.track.calledWith(sinon.match({

--- a/test/client/swg-controller/custom-handlers.spec.js
+++ b/test/client/swg-controller/custom-handlers.spec.js
@@ -42,7 +42,7 @@ describe('Swg Controller: custom handlers', function () {
 
 		sandbox.stub(utils.events, 'signal');
 		sandbox.stub(subject, 'resolveUser').returns(resolveUserPromise);
-		await subject.onSubscribeResponse(subPromise);
+		await subject.onPaymentResponse(subPromise);
 
 		expect(utils.events.signal.calledWith('onSubscribeReturn', MOCK_RESULT)).to.be.true;
 		expect(subject.track.getCall(0).calledWith(sinon.match({ action: 'success' }))).to.be.true;


### PR DESCRIPTION
I noticed this warning in Dev Tools Console when developing locally on `next-product`:

```
[swg.js:setOnSubscribeResponse]: This method has been deprecated, please switch usages to 'setOnPaymentResponse'
```

![Screenshot 2019-11-22 at 14 32 44](https://user-images.githubusercontent.com/10484515/69434197-0c5bec00-0d35-11ea-9f72-14d95452edb9.png)
