### PR TITLE
Move system-code var into demo SCSS entry point

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,3 +1,5 @@
+$system-code: n-swg !default;
+
 @import 'n-ui-foundations/main';
 @import '../../main';
 

--- a/main.scss
+++ b/main.scss
@@ -1,5 +1,3 @@
-$system-code: n-swg !default;
-
 // TODO: remove once Google have native disabled styling
 // from here
 .swg-button,


### PR DESCRIPTION
As per this commit description: https://github.com/Financial-Times/n-content-body/commit/7c567b535f2b63c7c4d5bfe976bef798a53b658c.

> **Update test to use a different Sass entry file**
> So that we can set system code which is required by some of the origmi components. We would set a default in the main file but we want this to break if a consumer doesn't set the system code.