### PR TITLE
chore: Remove sandbox from `n-swg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,6 @@ with the provided domain (it only works for ft.com at the time of writing).
 If not passed the config will be pulled by swg-js from JSON-LD markup.
 It is important to note that SwG will not work if it cannot find config */
 
-sandbox: false,
-/* [optional] if true imports the sandbox version of swg.js */
-
 subscribeFromButton: true,
 /* [optional] if true checkout flow will be initiated by clicking on
 [data-n-swg-button] elements */

--- a/demos/controllers/root.js
+++ b/demos/controllers/root.js
@@ -22,10 +22,6 @@ const getOffers = (mode) => {
 			{ name: 'FT.com premium (monthly)', sku: 'subs:com.ft.news:ft.com_713f1e28.0bc5.8261.f1e6.eebab6f7600e_p1m_premium_2018.05.21' },
 			{ name: 'FT.com premium (monthly)', sku: 'subs:com.ft.news:ft.com_713f1e28.0bc5.8261.f1e6.eebab6f7600e_p1y_premium_2018.05.21' }
 		],
-		sandbox: [
-			{ name: 'basic_daily_1 Dummy SKU', sku: 'basic_daily_1' },
-			{ name: 'premium_daily_1 Dummy SKU', sku: 'premium_daily_1' }
-		]
 	}[mode] || [];
 };
 

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -11,7 +11,6 @@ document.addEventListener('oErrors.log', e => {
 
 const options = {
 	manualInitDomain: !!(document.querySelector('[data-n-swg-demo-manual-mode=true]')) ? 'ft.com:subscribed' : false,
-	sandbox: !!(document.querySelector('[data-n-swg-demo-env=sandbox]')),
 	subscribeFromButton: true,
 	M_SWG_SUB_SUCCESS_ENDPOINT: !!(document.querySelector('[data-n-swg-local-proxy=true]')) && '/cors-endpoint/success',
 	M_SWG_ENTITLED_SUCCESS_ENDPOINT: !!(document.querySelector('[data-n-swg-local-proxy=true]')) && '/cors-endpoint/entitled',

--- a/demos/templates/index.html
+++ b/demos/templates/index.html
@@ -36,8 +36,6 @@
 		<button type="button" id="func-link">Experimental! Link account()</button>
 	</p>
 
-	<p>For now you can clear your sandbox subscriptions <a href="https://subscribe-autopush.sandbox.google.com/swg/dev/ft.com">here</a>.</p>
-
 	<p>Other scenarios:
 		<a href="/?production=true&paywall=true">Production env with paywall markup</a>,
 		<a href="/?paywall=true">Sandbox env with paywall markup</a>,

--- a/main-client.js
+++ b/main-client.js
@@ -4,7 +4,8 @@ const { importClient } = require('./src/client/utils');
 module.exports = {
 	SwgController,
 	swgLoader: (options={}) => new Promise((resolve, reject) => {
-		const loadOptions = { manual: !!options.manualInitDomain, sandbox: !!options.sandbox };
+		const loadOptions = { manual: !!options.manualInitDomain };
+
 		SwgController.load(loadOptions).then(client => {
 			const swg = new SwgController(client, options);
 			resolve(swg);

--- a/main-client.js
+++ b/main-client.js
@@ -10,7 +10,7 @@ module.exports = {
 			const swg = new SwgController(client, options);
 			resolve(swg);
 		})
-		.catch(reject);
+			.catch(reject);
 	}),
 	importClient: importClient()
 };

--- a/main-client.js
+++ b/main-client.js
@@ -10,7 +10,7 @@ module.exports = {
 			const swg = new SwgController(client, options);
 			resolve(swg);
 		})
-			.catch(reject);
+		.catch(reject);
 	}),
 	importClient: importClient()
 };

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -153,23 +153,23 @@ module.exports = class SwgController {
 					this.handlers.onResolvedSubscribe(res);
 				});
 			})
-			.catch(err => {
-			/**
-			 * TODO: UX
-			 * Could not resolve the user on our end after multiple retries.
-			 * The Google modal will timeout and still show the confirmation
-			 * modaul so we should still ensure there is an onward journey
-			 */
-				response.complete().then(() => {
-				/* track failure event */
-					this.track({ action: 'failure', context: {
-						stage: 'user-resolution'
-					}});
-					/* trigger onward journey */
-					this.onwardSubscriptionErrorJourney();
+				.catch(err => {
+					/**
+					 * TODO: UX
+					 * Could not resolve the user on our end after multiple retries.
+					 * The Google modal will timeout and still show the confirmation
+					 * modaul so we should still ensure there is an onward journey
+					 */
+					response.complete().then(() => {
+						/* track failure event */
+						this.track({ action: 'failure', context: {
+							stage: 'user-resolution'
+						}});
+						/* trigger onward journey */
+						this.onwardSubscriptionErrorJourney();
+					});
+					return Promise.reject(err); // re-throw for tracking
 				});
-				return Promise.reject(err); // re-throw for tracking
-			});
 		}).catch(err => {
 			/* signal error event to any listeners */
 			events.signalError(err);
@@ -251,40 +251,40 @@ module.exports = class SwgController {
 				headers: { 'content-type': 'application/json' },
 				body: payload
 			})
-			.then(({ json }) => {
-				const newlyCreated = _get(json, 'userInfo.newlyCreated');
-				const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
+				.then(({ json }) => {
+					const newlyCreated = _get(json, 'userInfo.newlyCreated');
+					const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
 
-				/**
-			 * Both subscription and entitlement callback endpoints return
-			 *  a 200 with set-cookie headers for the resolved user session
-			 *  and json about the new session.
-			 * If the user has just been created OR we can still see the
-			 *  NEW_SWG_SUB_COOKIE, then we still need to show them the
-			 *  consent page. The cookie gets deleted there.
-			 * Unless createSession was false we can assume user now has
-			 *  active session cookies
-			 */
-				resolve({
-					consentRequired: newlyCreated || hasNewSubCookie,
-					loginRequired: !newPurchaseFlow && createSession === false,
-					raw: json
+					/**
+					 * Both subscription and entitlement callback endpoints return
+					 *  a 200 with set-cookie headers for the resolved user session
+					 *  and json about the new session.
+					 * If the user has just been created OR we can still see the
+					 *  NEW_SWG_SUB_COOKIE, then we still need to show them the
+					 *  consent page. The cookie gets deleted there.
+					 * Unless createSession was false we can assume user now has
+					 *  active session cookies
+					 */
+					resolve({
+						consentRequired: newlyCreated || hasNewSubCookie,
+						loginRequired: !newPurchaseFlow && createSession === false,
+						raw: json
+					});
+				})
+				.catch((error) => {
+					if (retries === this.MAX_RETRIES) {
+						reject(error);
+					} else {
+						retries++;
+
+						this.track({ action: 'retry', context: {
+							stage: 'user-resolution',
+							retries
+						}});
+
+						this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
+					}
 				});
-			})
-			.catch((error) => {
-				if (retries === this.MAX_RETRIES) {
-					reject(error);
-				} else {
-					retries++;
-
-					this.track({ action: 'retry', context: {
-						stage: 'user-resolution',
-						retries
-					}});
-
-					this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
-				}
-			});
 		});
 	}
 
@@ -295,11 +295,11 @@ module.exports = class SwgController {
 	 */
 	hasAccount (subscriptionToken) {
 		return smartFetch.fetch(`${this.M_SWG_ACCOUNT_CHECK}`, {
-				method: 'POST',
-				credentials: 'include',
-				headers: { 'content-type': 'application/json' },
-				body: subscriptionToken
-			})
+			method: 'POST',
+			credentials: 'include',
+			headers: { 'content-type': 'application/json' },
+			body: subscriptionToken
+		})
 			.then(result => {
 				if (_get(result, 'json.active')) {
 					return true;

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -13,7 +13,7 @@ module.exports = class SwgController {
 		this.swgClient = swgClient;
 		this.manualInitDomain = options.manualInitDomain;
 		this.MAX_RETRIES = 2;
-		this.M_SWG_URL = options.sandbox ? 'https://api-t.ft.com/commerce' : 'https://api.ft.com/commerce';
+		this.M_SWG_URL = 'https://api.ft.com/commerce';
 		this.M_SWG_SUB_SUCCESS_ENDPOINT = options.M_SWG_SUB_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/v1/swg/subscriptions`;
 		this.M_SWG_ENTITLED_SUCCESS_ENDPOINT = options.M_SWG_ENTITLED_SUCCESS_ENDPOINT || `${this.M_SWG_URL}/v1/swg/subscriptions/entitlementsCheck`;
 		this.M_SWG_ACCOUNT_CHECK = options.M_SWG_ACCOUNT_CHECK || `${this.M_SWG_URL}/deferred-account`;
@@ -446,13 +446,12 @@ module.exports = class SwgController {
 	 * @param {boolean} manual - load swg client lib in manual mode
 	 * @param {promise} swgPromise - for mocking
 	 * @param {function} loadClient - for mocking
-	 * @param {boolean} sandbox - load sandbox swg client lib, defaults to prod
 	 * @returns {promise}
 	 */
-	static load ({ manual=false, swgPromise=swgReady(), loadClient=importClient, sandbox=false }={}) {
+	static load ({ manual=false, swgPromise=swgReady(), loadClient=importClient, }={}) {
 		return new Promise((resolve, reject) => {
 			try {
-				loadClient(document)({ manual, sandbox });
+				loadClient(document)({ manual });
 			} catch (e) {
 				reject(e);
 			}
@@ -480,7 +479,7 @@ module.exports = class SwgController {
 		return {
 			category: 'SwG',
 			formType: 'swg.signup',
-			production: !options.sandbox,
+			production: true,
 			paymentMethod: 'SWG',
 			system: { source: 'n-swg' }
 		};

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -153,23 +153,23 @@ module.exports = class SwgController {
 					this.handlers.onResolvedSubscribe(res);
 				});
 			})
-				.catch(err => {
-				/**
-				 * TODO: UX
-				 * Could not resolve the user on our end after multiple retries.
-				 * The Google modal will timeout and still show the confirmation
-				 * modaul so we should still ensure there is an onward journey
-				 */
-					response.complete().then(() => {
-					/* track failure event */
-						this.track({ action: 'failure', context: {
-							stage: 'user-resolution'
-						}});
-						/* trigger onward journey */
-						this.onwardSubscriptionErrorJourney();
-					});
-					return Promise.reject(err); // re-throw for tracking
+			.catch(err => {
+			/**
+			 * TODO: UX
+			 * Could not resolve the user on our end after multiple retries.
+			 * The Google modal will timeout and still show the confirmation
+			 * modaul so we should still ensure there is an onward journey
+			 */
+				response.complete().then(() => {
+				/* track failure event */
+					this.track({ action: 'failure', context: {
+						stage: 'user-resolution'
+					}});
+					/* trigger onward journey */
+					this.onwardSubscriptionErrorJourney();
 				});
+				return Promise.reject(err); // re-throw for tracking
+			});
 		}).catch(err => {
 			/* signal error event to any listeners */
 			events.signalError(err);
@@ -251,40 +251,40 @@ module.exports = class SwgController {
 				headers: { 'content-type': 'application/json' },
 				body: payload
 			})
-				.then(({ json }) => {
-					const newlyCreated = _get(json, 'userInfo.newlyCreated');
-					const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
+			.then(({ json }) => {
+				const newlyCreated = _get(json, 'userInfo.newlyCreated');
+				const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
 
-					/**
-				 * Both subscription and entitlement callback endpoints return
-				 *  a 200 with set-cookie headers for the resolved user session
-				 *  and json about the new session.
-				 * If the user has just been created OR we can still see the
-				 *  NEW_SWG_SUB_COOKIE, then we still need to show them the
-				 *  consent page. The cookie gets deleted there.
-				 * Unless createSession was false we can assume user now has
-				 *  active session cookies
-				 */
-					resolve({
-						consentRequired: newlyCreated || hasNewSubCookie,
-						loginRequired: !newPurchaseFlow && createSession === false,
-						raw: json
-					});
-				})
-				.catch((error) => {
-					if (retries === this.MAX_RETRIES) {
-						reject(error);
-					} else {
-						retries++;
-
-						this.track({ action: 'retry', context: {
-							stage: 'user-resolution',
-							retries
-						}});
-
-						this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
-					}
+				/**
+			 * Both subscription and entitlement callback endpoints return
+			 *  a 200 with set-cookie headers for the resolved user session
+			 *  and json about the new session.
+			 * If the user has just been created OR we can still see the
+			 *  NEW_SWG_SUB_COOKIE, then we still need to show them the
+			 *  consent page. The cookie gets deleted there.
+			 * Unless createSession was false we can assume user now has
+			 *  active session cookies
+			 */
+				resolve({
+					consentRequired: newlyCreated || hasNewSubCookie,
+					loginRequired: !newPurchaseFlow && createSession === false,
+					raw: json
 				});
+			})
+			.catch((error) => {
+				if (retries === this.MAX_RETRIES) {
+					reject(error);
+				} else {
+					retries++;
+
+					this.track({ action: 'retry', context: {
+						stage: 'user-resolution',
+						retries
+					}});
+
+					this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
+				}
+			});
 		});
 	}
 
@@ -295,11 +295,11 @@ module.exports = class SwgController {
 	 */
 	hasAccount (subscriptionToken) {
 		return smartFetch.fetch(`${this.M_SWG_ACCOUNT_CHECK}`, {
-			method: 'POST',
-			credentials: 'include',
-			headers: { 'content-type': 'application/json' },
-			body: subscriptionToken
-		})
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' },
+				body: subscriptionToken
+			})
 			.then(result => {
 				if (_get(result, 'json.active')) {
 					return true;

--- a/src/client/utils/swg-client-loader.js
+++ b/src/client/utils/swg-client-loader.js
@@ -1,11 +1,11 @@
-module.exports = (_document=document) => ({ manual=false, src, id='swg-client', sandbox=false }={}) => {
+module.exports = (_document=document) => ({ manual=false, src, id='swg-client' }={}) => {
 	const hasClientAlready = id && !!_document.querySelector('#' + id);
 	// Prevent importing more than once.
 	if (hasClientAlready) return;
 
 	let script = _document.createElement('SCRIPT');
 
-	script.src = src || (sandbox ? 'https://news.google.com/swg/js/v1/swg-tt.js' : 'https://news.google.com/swg/js/v1/swg.js');
+	script.src = src || 'https://news.google.com/swg/js/v1/swg.js';
 	script.async = true;
 	script.id = id;
 

--- a/test/client/main-bower.js
+++ b/test/client/main-bower.js
@@ -53,8 +53,8 @@ describe('Bower main-client.js', function () {
 
 		it('calls SwgController.load() with correct options', function (done) {
 			sinon.stub(SwgController, 'load').resolves(new swgClientMock());
-			subject.swgLoader({ manualInitDomain: 'ft.com', sandbox: true }).then(() => {
-				expect(SwgController.load.calledWith({ manual: true, sandbox: true })).to.be.true;
+			subject.swgLoader({ manualInitDomain: 'ft.com' }).then(() => {
+				expect(SwgController.load.calledWith({ manual: true })).to.be.true;
 				SwgController.load.restore();
 				done();
 			})
@@ -67,7 +67,7 @@ describe('Bower main-client.js', function () {
 		it('on successful .load() resolves with an instance of the SwgController class', function (done) {
 			sinon.stub(SwgController, 'load').resolves(new swgClientMock());
 			subject.swgLoader().then((swg) => {
-				expect(SwgController.load.calledWith({ manual: false, sandbox: false })).to.be.true;
+				expect(SwgController.load.calledWith({ manual: false})).to.be.true;
 				expect(swg).to.be.an.instanceOf(SwgController);
 				SwgController.load.restore();
 				done();
@@ -82,7 +82,7 @@ describe('Bower main-client.js', function () {
 			const MOCK_ERROR = new Error('loading failed');
 			sinon.stub(SwgController, 'load').throws(MOCK_ERROR);
 			subject.swgLoader().catch((err) => {
-				expect(SwgController.load.calledWith({ manual: false, sandbox: false })).to.be.true;
+				expect(SwgController.load.calledWith({ manual: false })).to.be.true;
 				expect(err).to.be.equal(MOCK_ERROR);
 				SwgController.load.restore();
 				done();

--- a/test/client/main-bower.js
+++ b/test/client/main-bower.js
@@ -58,10 +58,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-				.catch(err => {
-					SwgController.load.restore();
-					done(err);
-				});
+			.catch(err => {
+				SwgController.load.restore();
+				done(err);
+			});
 		});
 
 		it('on successful .load() resolves with an instance of the SwgController class', function (done) {
@@ -72,10 +72,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-				.catch(err => {
-					SwgController.load.restore();
-					done(err);
-				});
+			.catch(err => {
+				SwgController.load.restore();
+				done(err);
+			});
 		});
 
 		it('on error in .load() rejects with an error', function (done) {
@@ -87,10 +87,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-				.catch(err => {
-					SwgController.load.restore();
-					done(err);
-				});
+			.catch(err => {
+				SwgController.load.restore();
+				done(err);
+			});
 		});
 
 	});

--- a/test/client/main-bower.js
+++ b/test/client/main-bower.js
@@ -58,10 +58,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 		it('on successful .load() resolves with an instance of the SwgController class', function (done) {
@@ -72,10 +72,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 		it('on error in .load() rejects with an error', function (done) {
@@ -87,10 +87,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 	});

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -84,7 +84,7 @@ describe('Swg Controller: class', function () {
 			expect(swgClient.setOnPaymentResponse.calledOnce).to.be.true;
 			expect(swgClient.setOnEntitlementsResponse.calledOnce).to.be.true;
 			expect(subject.swgClient).to.deep.equal(swgClient);
-	});
+		});
 
 	});
 
@@ -254,8 +254,8 @@ describe('Swg Controller: class', function () {
 			expect(subject.track.calledWith(sinon.match({
 				action: 'exit',
 				context: {
-						errCode: MOCK_ERROR.activityResult.code,
-						errData: MOCK_ERROR.activityResult.data
+					errCode: MOCK_ERROR.activityResult.code,
+					errData: MOCK_ERROR.activityResult.data
 				}
 			}))).to.be.true;
 		});
@@ -318,20 +318,20 @@ describe('Swg Controller: class', function () {
 			fetchStub.resolves({ json: MOCK_RESULT });
 
 			const result = await subject.resolveUser(subject.ENTITLED_USER, MOCK_SWG_RESPONSE, false);
-				expect(result).to.deep.equal({
-					loginRequired: true,
-					consentRequired: false,
-					raw: MOCK_RESULT
-				});
-				expect(fetchStub.calledWith(MOCK_M_SWG_ENTITLED_SUCCESS_ENDPOINT, {
-					method: 'POST',
-					body: expectedBody,
-					credentials: 'include',
-					headers: {
-						'content-type': 'application/json'
-					}
-				})).to.be.true;
+			expect(result).to.deep.equal({
+				loginRequired: true,
+				consentRequired: false,
+				raw: MOCK_RESULT
 			});
+			expect(fetchStub.calledWith(MOCK_M_SWG_ENTITLED_SUCCESS_ENDPOINT, {
+				method: 'POST',
+				body: expectedBody,
+				credentials: 'include',
+				headers: {
+					'content-type': 'application/json'
+				}
+			})).to.be.true;
+		});
 
 		it('scenario=NEW_USER correctly formats (NEW USER) and handles request from passed options', async function () {
 			const MOCK_SWG_RESPONSE = { swgToken: '123' };

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -85,7 +85,6 @@ describe('Swg Controller: class', function () {
 			expect(swgClient.setOnEntitlementsResponse.calledOnce).to.be.true;
 			expect(subject.swgClient).to.deep.equal(swgClient);
 		});
-
 	});
 
 	describe('.init()', function () {

--- a/test/client/swg-controller/static-methods.spec.js
+++ b/test/client/swg-controller/static-methods.spec.js
@@ -61,7 +61,7 @@ describe('Swg Controller: static methods', function () {
 	describe('.generateTrackingData()', function () {
 
 		it('generates basic tracking data', function () {
-			const result = SwgController.generateTrackingData({ sandbox: true });
+			const result = SwgController.generateTrackingData();
 			expect(result).to.deep.equal({
 				category: 'SwG',
 				formType: 'swg.signup',

--- a/test/client/utils/swg-client-loader.spec.js
+++ b/test/client/utils/swg-client-loader.spec.js
@@ -46,15 +46,6 @@ describe('Util: swg-client-loader.js', function () {
 			expect(resultEl.id).to.equal('swg-client');
 		});
 
-		it('with correct default attributes in sandbox mode', function () {
-			subject({ sandbox: true });
-			const resultEl = dom.querySelector(defaultSelector);
-			expect(resultEl.getAttribute('src')).to.equal('https://news.google.com/swg/js/v1/swg-tt.js');
-			expect(resultEl.async).to.equal(true);
-			expect(resultEl.getAttribute('subscriptions-control')).to.be.null;
-			expect(resultEl.id).to.equal('swg-client');
-		});
-
 		it('with correct custom attributes if passed', function () {
 			subject({ id: 'bar', manual: true, src: 'https://foo.com/file.js' });
 			const resultEl = dom.querySelector('#bar');


### PR DESCRIPTION
Google no longer supports the sandbox version of `swg.js`. 🤦‍♂ 

From the [SWG docs](https://developers.google.com/news/subscribe/guides/test-web-integration):

> You must test your buy flow implementation with real forms of payment and issue refunds through the Play Console.
> 
> It’s recommended that you use a SKU with a free trial

With this in mind, I've removed the `sandbox` flag.

NOTE: The indentations are a result of running `make verifty`.