### PR TITLE
Add `isReadyToPay` util method 🐿 v2.12.5

### DIFF
--- a/main-client.js
+++ b/main-client.js
@@ -9,7 +9,7 @@ module.exports = {
 			const swg = new SwgController(client, options);
 			resolve(swg);
 		})
-		.catch(reject);
+			.catch(reject);
 	}),
 	importClient: importClient()
 };

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -130,7 +130,7 @@ module.exports = class SwgController {
 	}
 
 	/**
-	 * Get a user's `isReadyToPay` entitlement.
+	 * Get a user's `isReadyToPay` entitlement - if a user has a Google account with an associated payment method like a credit card or Google Pay.
 	 * @returns {promise} - resolves with a `boolean`
 	 */
 	isReadyToPay () {
@@ -162,23 +162,23 @@ module.exports = class SwgController {
 					this.handlers.onResolvedSubscribe(res);
 				});
 			})
-			.catch(err => {
+				.catch(err => {
 				/**
 				 * TODO: UX
 				 * Could not resolve the user on our end after multiple retries.
 				 * The Google modal will timeout and still show the confirmation
 				 * modaul so we should still ensure there is an onward journey
 				 */
-				response.complete().then(() => {
+					response.complete().then(() => {
 					/* track failure event */
-					this.track({ action: 'failure', context: {
-						stage: 'user-resolution'
-					}});
-					/* trigger onward journey */
-					this.onwardSubscriptionErrorJourney();
+						this.track({ action: 'failure', context: {
+							stage: 'user-resolution'
+						}});
+						/* trigger onward journey */
+						this.onwardSubscriptionErrorJourney();
+					});
+					return Promise.reject(err); // re-throw for tracking
 				});
-				return Promise.reject(err); // re-throw for tracking
-			});
 		}).catch(err => {
 			/* signal error event to any listeners */
 			events.signalError(err);
@@ -260,11 +260,11 @@ module.exports = class SwgController {
 				headers: { 'content-type': 'application/json' },
 				body: payload
 			})
-			.then(({ json }) => {
-				const newlyCreated = _get(json, 'userInfo.newlyCreated');
-				const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
+				.then(({ json }) => {
+					const newlyCreated = _get(json, 'userInfo.newlyCreated');
+					const hasNewSubCookie = document.cookie.indexOf(this.NEW_SWG_SUB_COOKIE) !== -1;
 
-				/**
+					/**
 				 * Both subscription and entitlement callback endpoints return
 				 *  a 200 with set-cookie headers for the resolved user session
 				 *  and json about the new session.
@@ -274,26 +274,26 @@ module.exports = class SwgController {
 				 * Unless createSession was false we can assume user now has
 				 *  active session cookies
 				 */
-				resolve({
-					consentRequired: newlyCreated || hasNewSubCookie,
-					loginRequired: !newPurchaseFlow && createSession === false,
-					raw: json
+					resolve({
+						consentRequired: newlyCreated || hasNewSubCookie,
+						loginRequired: !newPurchaseFlow && createSession === false,
+						raw: json
+					});
+				})
+				.catch((error) => {
+					if (retries === this.MAX_RETRIES) {
+						reject(error);
+					} else {
+						retries++;
+
+						this.track({ action: 'retry', context: {
+							stage: 'user-resolution',
+							retries
+						}});
+
+						this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
+					}
 				});
-			})
-			.catch((error) => {
-				if (retries === this.MAX_RETRIES) {
-					reject(error);
-				} else {
-					retries++;
-
-					this.track({ action: 'retry', context: {
-						stage: 'user-resolution',
-						retries
-					}});
-
-					this.resolveUser(scenario, swgResponse, createSession, retries).then(resolve).catch(reject);
-				}
-			});
 		});
 	}
 
@@ -304,11 +304,11 @@ module.exports = class SwgController {
 	 */
 	hasAccount (subscriptionToken) {
 		return smartFetch.fetch(`${this.M_SWG_ACCOUNT_CHECK}`, {
-				method: 'POST',
-				credentials: 'include',
-				headers: { 'content-type': 'application/json' },
-				body: subscriptionToken
-			})
+			method: 'POST',
+			credentials: 'include',
+			headers: { 'content-type': 'application/json' },
+			body: subscriptionToken
+		})
 			.then(result => {
 				if (_get(result, 'json.active')) {
 					return true;

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -51,6 +51,24 @@ module.exports = class SwgController {
 		/* symbols */
 		this.ENTITLED_USER = 'entitled_user';
 		this.NEW_USER = 'new_user';
+
+
+		this.init = this.init.bind(this)
+		this.checkEntitlements = this.checkEntitlements.bind(this)
+		this.getReadyToPayBool = this.getReadyToPayBool.bind(this)
+		this.onPaymentResponse = this.onPaymentResponse.bind(this)
+		this.onFlowStarted = this.onFlowStarted.bind(this)
+		this.onFlowCanceled = this.onFlowCanceled.bind(this)
+		this.onEntitlementsResponse = this.onEntitlementsResponse.bind(this)
+		this.onLoginRequest = this.onLoginRequest.bind(this)
+		this.resolveUser = this.resolveUser.bind(this)
+		this.hasAccount = this.hasAccount.bind(this)
+		this.defaultOnwardEntitledJourney = this.defaultOnwardEntitledJourney.bind(this)
+		this.defaultOnwardSubscribedJourney = this.defaultOnwardSubscribedJourney.bind(this)
+		this.onwardSubscriptionErrorJourney = this.onwardSubscriptionErrorJourney.bind(this)
+		this.track = this.track.bind(this)
+		this.errorEventHandler = this.errorEventHandler.bind(this)
+		this.setNewSwgSubscriberCookie = this.setNewSwgSubscriberCookie.bind(this)
 	}
 
 	/**
@@ -84,7 +102,7 @@ module.exports = class SwgController {
 			if (disableEntitlementsCheck) {
 				/* no entitlements check, enable buttons */
 				if (this.subscribeButtons) this.subscribeButtons.init();
-				resolve();
+				resolve(this);
 			} else {
 				/* handle entitlements check invoked by Google on init */
 				initialEntitlementsCheck.then((res={}) => {
@@ -94,7 +112,7 @@ module.exports = class SwgController {
 						 * a barrier, so prompt them to login and create an
 						 * FT.com session for their SwG account */
 						this.handlers.onResolvedEntitlements(res);
-						resolve();
+						resolve(this);
 					} else if (res.hasEntitlements) {
 						/* User has entitlements but not to requested content
 						 * so barrier is relevant. Show a dismissible message
@@ -110,11 +128,11 @@ module.exports = class SwgController {
 						 * - prompt login if they do not ?
 						 * - FUTURE (?) enable "upgrade" SwG buttons
 						 * */
-						resolve();
+						resolve(this);
 					} else {
 						/* no entitlements, enable buttons */
 						if (this.subscribeButtons) this.subscribeButtons.init();
-						resolve();
+						resolve(this);
 					}
 				});
 			}
@@ -127,6 +145,16 @@ module.exports = class SwgController {
 	 */
 	checkEntitlements () {
 		return this.swgClient.getEntitlements().then(SwgController.handleEntitlementsCallback);
+	}
+
+	/**
+	 * Get a user's `isReadyToPay` entitlement.
+	 * @returns {promise} - resolves with a boolean boolean`
+	 */
+
+	getReadyToPayBool() {
+		return this.swgClient.getEntitlements()
+			.then(({ isReadyToPay }) => isReadyToPay)
 	}
 
 	/**

--- a/src/client/swg-controller.js
+++ b/src/client/swg-controller.js
@@ -51,24 +51,6 @@ module.exports = class SwgController {
 		/* symbols */
 		this.ENTITLED_USER = 'entitled_user';
 		this.NEW_USER = 'new_user';
-
-
-		this.init = this.init.bind(this)
-		this.checkEntitlements = this.checkEntitlements.bind(this)
-		this.getReadyToPayBool = this.getReadyToPayBool.bind(this)
-		this.onPaymentResponse = this.onPaymentResponse.bind(this)
-		this.onFlowStarted = this.onFlowStarted.bind(this)
-		this.onFlowCanceled = this.onFlowCanceled.bind(this)
-		this.onEntitlementsResponse = this.onEntitlementsResponse.bind(this)
-		this.onLoginRequest = this.onLoginRequest.bind(this)
-		this.resolveUser = this.resolveUser.bind(this)
-		this.hasAccount = this.hasAccount.bind(this)
-		this.defaultOnwardEntitledJourney = this.defaultOnwardEntitledJourney.bind(this)
-		this.defaultOnwardSubscribedJourney = this.defaultOnwardSubscribedJourney.bind(this)
-		this.onwardSubscriptionErrorJourney = this.onwardSubscriptionErrorJourney.bind(this)
-		this.track = this.track.bind(this)
-		this.errorEventHandler = this.errorEventHandler.bind(this)
-		this.setNewSwgSubscriberCookie = this.setNewSwgSubscriberCookie.bind(this)
 	}
 
 	/**
@@ -149,12 +131,11 @@ module.exports = class SwgController {
 
 	/**
 	 * Get a user's `isReadyToPay` entitlement.
-	 * @returns {promise} - resolves with a boolean boolean`
+	 * @returns {promise} - resolves with a `boolean`
 	 */
-
-	getReadyToPayBool() {
+	isReadyToPay () {
 		return this.swgClient.getEntitlements()
-			.then(({ isReadyToPay }) => isReadyToPay)
+			.then(({ isReadyToPay }) => isReadyToPay);
 	}
 
 	/**

--- a/test/client/main-bower.js
+++ b/test/client/main-bower.js
@@ -58,10 +58,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 		it('on successful .load() resolves with an instance of the SwgController class', function (done) {
@@ -72,10 +72,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 		it('on error in .load() rejects with an error', function (done) {
@@ -87,10 +87,10 @@ describe('Bower main-client.js', function () {
 				SwgController.load.restore();
 				done();
 			})
-			.catch(err => {
-				SwgController.load.restore();
-				done(err);
-			});
+				.catch(err => {
+					SwgController.load.restore();
+					done(err);
+				});
 		});
 
 	});

--- a/test/client/swg-controller/class.spec.js
+++ b/test/client/swg-controller/class.spec.js
@@ -84,7 +84,7 @@ describe('Swg Controller: class', function () {
 			expect(swgClient.setOnPaymentResponse.calledOnce).to.be.true;
 			expect(swgClient.setOnEntitlementsResponse.calledOnce).to.be.true;
 			expect(subject.swgClient).to.deep.equal(swgClient);
-	});
+		});
 
 	});
 
@@ -254,8 +254,8 @@ describe('Swg Controller: class', function () {
 			expect(subject.track.calledWith(sinon.match({
 				action: 'exit',
 				context: {
-						errCode: MOCK_ERROR.activityResult.code,
-						errData: MOCK_ERROR.activityResult.data
+					errCode: MOCK_ERROR.activityResult.code,
+					errData: MOCK_ERROR.activityResult.data
 				}
 			}))).to.be.true;
 		});
@@ -318,20 +318,20 @@ describe('Swg Controller: class', function () {
 			fetchStub.resolves({ json: MOCK_RESULT });
 
 			const result = await subject.resolveUser(subject.ENTITLED_USER, MOCK_SWG_RESPONSE, false);
-				expect(result).to.deep.equal({
-					loginRequired: true,
-					consentRequired: false,
-					raw: MOCK_RESULT
-				});
-				expect(fetchStub.calledWith(MOCK_M_SWG_ENTITLED_SUCCESS_ENDPOINT, {
-					method: 'POST',
-					body: expectedBody,
-					credentials: 'include',
-					headers: {
-						'content-type': 'application/json'
-					}
-				})).to.be.true;
+			expect(result).to.deep.equal({
+				loginRequired: true,
+				consentRequired: false,
+				raw: MOCK_RESULT
 			});
+			expect(fetchStub.calledWith(MOCK_M_SWG_ENTITLED_SUCCESS_ENDPOINT, {
+				method: 'POST',
+				body: expectedBody,
+				credentials: 'include',
+				headers: {
+					'content-type': 'application/json'
+				}
+			})).to.be.true;
+		});
 
 		it('scenario=NEW_USER correctly formats (NEW USER) and handles request from passed options', async function () {
 			const MOCK_SWG_RESPONSE = { swgToken: '123' };


### PR DESCRIPTION
 - Return `swg` instance from `init` promise so it can be used in a follow up async method.
 - Explicity bind all functions in class to instance. 
 - Add check for whether or not a user is ready to pay.

[Ticket](https://financialtimes.atlassian.net/browse/AC-49?atlOrigin=eyJpIjoiNTk3MTdlMGRjM2Q1NGNlM2I3ODg0MGJmODk3MTBkMDEiLCJwIjoiaiJ9)
