### PR TITLE
ACQ-22: Require approving review when merging to master

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,10 @@ _extends: github-apps-config-next
 branches:
   - name: master
     protection:
-      required_pull_request_reviews: null
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
       required_status_checks:
         strict: true
         contexts:


### PR DESCRIPTION
Adds the following protections to master branch:
- at least one approving review
- build-test must have run and passed