### PR TITLE
NOPS-253 Remove n-webpack dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/Financial-Times/n-swg#readme",
   "dependencies": {},
   "devDependencies": {
-    "@financial-times/n-gage": "^3.6.0",
+    "@financial-times/n-gage": "^5.0.0",
     "@financial-times/n-internal-tool": "^2.2.2",
     "@financial-times/n-logger": "^5.6.3",
     "@financial-times/n-test": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@financial-times/n-internal-tool": "^2.2.2",
     "@financial-times/n-logger": "^5.6.3",
     "@financial-times/n-test": "^1.0.1",
-    "@financial-times/n-webpack": "^3.1.0",
     "@financial-times/next-json-ld": "^0.4.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "JS, Styles, Templates and utils for FT.com Subscribe with Google implementation",
   "main": "main.js",
   "scripts": {
-    "precommit": "node_modules/.bin/secret-squirrel",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make verify -j3",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "repository": {
@@ -48,5 +45,12 @@
     "request": "^2.83.0",
     "sinon": "^4.4.2",
     "snyk": "^1.168.0"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-push": "make verify -j3"
+    }
   }
 }


### PR DESCRIPTION
- Updates to n-gage v5.
- Removes dependency on https://github.com/Financial-Times/n-webpack because you can not install dev dependencies because of an issue with node-sass caused by that package.
- FYI Make demo will no longer work so a new webpack config will need to be written for the demo.